### PR TITLE
#6 Fix exception if an NMT command is received without a registered device

### DIFF
--- a/src/Network.js
+++ b/src/Network.js
@@ -85,7 +85,9 @@ class Network extends EventEmitter {
                     this.devices[id].state = state;
             }
             else {
-                this.devices[target].state = state;
+                if (this.devices[target]) {
+                    this.devices[target].state = state;
+                }
             }
         }
         else if((message.id & 0x7F0) == 0x80) {


### PR DESCRIPTION
The code here assumed there was a device registered for the given
received NMT node ID. If there wasn't one, then a TypeError would be
thrown. This commit changes it to check if a device is registered before
we try and access it.

Fixes #6