### PR TITLE
Fix SDO transfer exceptions and add new tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "documentation": "^8.1.2",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "socketcan": "^2.7.1"
   },
   "engines": {
     "node": ">=10"

--- a/src/COError.js
+++ b/src/COError.js
@@ -48,7 +48,9 @@ class COError extends Error {
         if(message === undefined)
             message = "Unknown error"
 
-        let tag = `0x${index.toString(16)}`;
+        let tag = index
+        if (typeof index === 'number')
+            tag = `0x${index.toString(16)}`;
         if(subIndex !== null)
             tag += `.${subIndex.toString()}`;
 

--- a/src/EDS.js
+++ b/src/EDS.js
@@ -450,7 +450,7 @@ class DataObject extends EventEmitter {
 
         /* Create raw data buffer. */
         if(DefaultValue !== undefined) {
-            this._raw = typeToRaw(DefaultValue, DataType);
+            this._raw = typeToRaw(DefaultValue, parseInt(DataType));
             Object.defineProperty(this, '_raw', {
                 enumerable: false,
             });
@@ -810,7 +810,7 @@ class EDS {
      * @return {DataObject} - the sub-entry at index.
      */
     getSubEntry(index, subIndex) {
-        const entry = this._dataObjects[index];
+        const entry = this.getEntry(index);
         if(!entry)
             throw new COError(0x06020000, index, subIndex);
         else if(entry.SubNumber === undefined)

--- a/src/protocol/SDO.js
+++ b/src/protocol/SDO.js
@@ -537,7 +537,7 @@ class SDO {
                 return transfer.abort(0x06020000);
 
             if(entry.subNumber > 0) {
-                entry = entry[subIndex];
+                entry = entry[transfer.subIndex];
                 if(!entry)
                     return transfer.abort(0x06090011);
             }
@@ -602,7 +602,7 @@ class SDO {
             return transfer.abort(0x06020000);
 
         if(entry.subNumber > 0) {
-            entry = entry[subIndex];
+            entry = entry[transfer.subIndex];
             if(!entry)
                 return transfer.abort(0x06090011);
         }
@@ -707,7 +707,7 @@ class SDO {
                 return transfer.abort(0x06020000);
 
             if(entry.subNumber > 0) {
-                entry = entry[subIndex];
+                entry = entry[transfer.subIndex];
                 if(!entry)
                     return transfer.abort(0x06090011);
             }

--- a/test/protocol/testSDO.js
+++ b/test/protocol/testSDO.js
@@ -142,6 +142,39 @@ describe('SDO', function() {
                 });
             });
         }
+
+        it('should be able to transfer with subindexes >= 1', async function() {
+            const testString = 'I am a quite a long string that will take multiple messages to transfer'
+            node.init();
+            node.EDS.addEntry(0x1234, {
+                ParameterName:    'Test entry',
+                ObjectType:       6,
+                SubNumber:        1
+            });
+            node.EDS.addSubEntry(0x1234, 0, {
+                ParameterName:      'A long name',
+                DataType:           EDS.dataTypes.VISIBLE_STRING,
+                AccessType:         EDS.accessTypes.READ_WRITE,
+                DefaultValue:       testString,
+            })
+
+            const result = await node.SDO.upload({
+                serverId: node.id,
+                index: 0x1234,
+                subIndex: 0,
+                dataType: EDS.dataTypes.VISIBLE_STRING
+            });
+
+            expect(result).to.equal(testString)
+
+            return node.SDO.download({
+                serverId: node.id,
+                data: result,
+                dataType: EDS.dataTypes.VISIBLE_STRING,
+                index: 0x1234,
+                subIndex: 0
+            })
+        })
     });
 
     describe('Error handling', function() {
@@ -154,7 +187,7 @@ describe('SDO', function() {
                 serverId: 0x1,
                 index: 0x1000,
                 subIndex: 1
-            })).to.be.rejectedWith(COError);
+            })).to.be.rejectedWith("SDO protocol timed out");
         });
     });
 });

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -1,0 +1,10 @@
+[1234]
+ParameterName=DeviceInfo
+ObjectType=8
+SubNumber=1
+
+[1234sub0]
+ParameterName=DeviceName
+DataType=9
+AccessType=ro
+DefaultValue=Test

--- a/test/testEDS.js
+++ b/test/testEDS.js
@@ -50,6 +50,14 @@ describe('EDS', function() {
                 expect(loadFile.creationDate.getTime()).to.equal(date.getTime()),
             ])
         });
+
+        it('should create a raw entry if there is a DefaultValue', function() {
+            const loadFile = new EDS.EDS();
+            loadFile.load('test/sample.eds');
+
+            const entry = loadFile.getSubEntry('DeviceInfo', 0)
+            expect(entry.raw).to.not.be.undefined
+        });
     });
 
     describe('Add entry', function() {


### PR DESCRIPTION
PR fixes a few exceptions/issues I encountered when trying out the new beta branch:

When reading or writing to a subindex >= 1, an exception would be thrown, as "subIndex" is not defined, and should instead be "transfer.subIndex". Commit also includes new tests that verify these now work correctly. Also changes the SDO timeout test to verify it is the right exception. I changed EDS' getSubEntry to call this.getEntry when looking up the index, as otherwise it is not possible to use a string as the index value like the JSDoc suggests

Lastly fixes EDS.load failing to create a raw for an object because DataType was not parsed as an int, causing typeToRaw to fail to return a correct value. A test has been added for this as well.

I've also added socketcan to devDependencies as the demos cannot be run without it. 