### PR TITLE
Fix error when this.raw is undefined, and fix COError creation

### DIFF
--- a/src/EDS.js
+++ b/src/EDS.js
@@ -546,7 +546,7 @@ class DataObject extends EventEmitter {
         if(raw === undefined)
             raw = typeToRaw(value, this.dataType);
 
-        if(Buffer.compare(raw, this.raw) == 0)
+        if(this.raw !== undefined && Buffer.compare(raw, this.raw) == 0)
             return;
 
         if(!this.accessType.includes('w'))
@@ -673,7 +673,7 @@ class EDS {
                     this.addSubEntry(index, subIndex, value);
                 }
                 catch(error) {
-                    const load_error = COError(0x08000023, index, subIndex);
+                    const load_error = new COError(0x08000023, index, subIndex);
                     load_error.stack = error.stack;
                     throw load_error;
                 }


### PR DESCRIPTION
Two more small things I noticed this morning - COError needed to be called with "new" and if DefaultValue in the EDS was empty, this.raw would be undefined in src/EDS.js. When later trying to write to it via SDO, the corrected line would fail, as Buffer.compare would be given "undefined" as the second arg. Change adds a check to see if this.raw is not undefined.