### PR TITLE
fixed timeout issue for big sdo block transfers

### DIFF
--- a/source/device.js
+++ b/source/device.js
@@ -132,13 +132,14 @@ class Device extends EventEmitter {
      * @param {number} message.id - CAN message identifier.
      * @param {Buffer} message.data - CAN message data;
      * @param {number} message.len - CAN message length in bytes.
+     * @return {number} number of bytes sent or -1 for error
      * @protected
      */
     send(message) {
         if(this._send === null)
             throw ReferenceError("please call setTransmitFunction() first");
 
-        this._send(message);
+        return this._send(message);
     }
 
     /**

--- a/source/device.js
+++ b/source/device.js
@@ -132,7 +132,7 @@ class Device extends EventEmitter {
      * @param {number} message.id - CAN message identifier.
      * @param {Buffer} message.data - CAN message data;
      * @param {number} message.len - CAN message length in bytes.
-     * @return {number} number of bytes sent or -1 for error
+     * @returns {number} number of bytes sent or -1 for error
      * @protected
      */
     send(message) {

--- a/source/protocol/sdo.js
+++ b/source/protocol/sdo.js
@@ -311,9 +311,10 @@ class SdoTransfer {
      * Send a data buffer.
      *
      * @param {Buffer} data - data to send.
+     * @return {number} Number of bits sent or -1 for error
      */
     send(data) {
-        this.device.send({
+        return this.device.send({
             id: this.cobId,
             data: data,
         });

--- a/source/protocol/sdo.js
+++ b/source/protocol/sdo.js
@@ -311,7 +311,7 @@ class SdoTransfer {
      * Send a data buffer.
      *
      * @param {Buffer} data - data to send.
-     * @return {number} Number of bits sent or -1 for error
+     * @returns {number} Number of bits sent or -1 for error
      */
     send(data) {
         return this.device.send({

--- a/source/protocol/sdo_client.js
+++ b/source/protocol/sdo_client.js
@@ -96,6 +96,8 @@ class SdoClient {
         this.servers = {};
         this.transfers = {};
         this._blockSize = 127;
+        // Minimum timeout for the sdo block download.
+        this._blockDownloadTimeout = 1;
     }
 
     /**
@@ -619,11 +621,6 @@ class SdoClient {
     }
 
     /**
-     * Minimum timeout for the sdo block download.
-    */
-    blockDownloadTimeout = 1
-
-    /**
      * Download a data block.
      *
      * Sub-blocks are scheduled using setInterval to avoid blocking during
@@ -646,8 +643,8 @@ class SdoClient {
                 return;
             }
 
-            if(this.blockDownloadTimeout > 1){
-                this.blockDownloadTimeout = this.blockDownloadTimeout >> 1;
+            if(this._blockDownloadTimeout > 1){
+                this._blockDownloadTimeout = this._blockDownloadTimeout >> 1;
             }
 
             const sendBuffer = Buffer.alloc(8);
@@ -663,7 +660,7 @@ class SdoClient {
             transfer.data.copy(sendBuffer, 1, offset, offset + 7);
             const ret = transfer.send(sendBuffer);
             if(ret < 0 ){
-                this.blockDownloadTimeout = this.blockDownloadTimeout << 8;
+                this._blockDownloadTimeout = this._blockDownloadTimeout << 8;
                 transfer.blockSequence -= 1
             }
             transfer.refresh();
@@ -673,7 +670,7 @@ class SdoClient {
                 clearInterval(transfer.blockInterval);
                 transfer.blockInterval = null;
             }
-        }, this.blockDownloadTimeout);
+        }, this._blockDownloadTimeout);
     }
 
     /**


### PR DESCRIPTION
Hello, 
first of all, thank you for the code. I use it in a project, where we send a lot of small data. 
At one point, we want to send big data (1MB) over the can. It works great, as long as there is nothing else on the network.
If there are other packages, the sdo block transfer will just stop and don't tell anything. 

I figured out a way around this issue. The SDO block transfer is just trying to send as much as possible, even though the can connection is to full. But luckly the socketcan package helps us out of this. 

Thats why we want the return value of the send method, it tells us if the message got transmitted succesfully. 

On the other hand, I update the interval timeout, to give the can some time to recover after it filled up. For now this code seems to work fine, but It could run into issues if you have multiple sdo block transfers. What could happen then, is, it will give the Can channel more time to recover, because two messages try to send at the same time. 
I was not sure what a good way is to track the download, so I did it in one variable. This can result in slower download when running multiple block transfers. 

Let me know what you think about this and Cheers