### PR TITLE
fixed pdo refresh error

### DIFF
--- a/source/protocol/sdo.js
+++ b/source/protocol/sdo.js
@@ -301,7 +301,7 @@ class SdoTransfer {
 
     /** Refresh the transfer timeout. */
     refresh() {
-        if(!this.timeout)
+        if(!this.timeout || this.timer == null)
             return;
 
         this.timer.refresh();


### PR DESCRIPTION
Hello, 
there is a problem with the refresh method of the `sdo.js`. In line 307 it is calling `this.time.refresh()`. With your code it is possible, that `this.timer` can be null and in my case sometimes the application crashes because of this. 
I'm still trying to find out when exactly this is happening, but even though I couldn't find the exact order in which what has to happen, wouldn't it be cleaner code if you check before you run `refresh()` to check if it is `null` and just terminate the function?
